### PR TITLE
Remake module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ provider "pagerduty" {
   token = "Pagerduty_Token"
 }
 module "pagerduty_escalation" {
-  source                      = "git@github.com:hazelops/terraform-pagerduty-escalation-policy.git"
-  escalation_policy_target_id = module.pagerduty_schedule.id
+  source  = "hazelops/escalation-policy/pagerduty"
+  escalation_policy_users_targets =    [module.pagerduty_users.id]
   name                        = "test"
 }
 
@@ -34,14 +34,15 @@ provider "pagerduty" {
   token = "Pagerduty_Token"
 }
 module "pagerduty_escalation" {
-  source                      = "git@github.com:hazelops/terraform-pagerduty-escalation-policy.git"
+  source  = "hazelops/escalation-policy/pagerduty"
   enabled                     = true
   escalation_delay_in_minutes = 10
-  escalation_policy_target_id = module.pagerduty_user.id
+  escalation_policy_users_targets =    [module.pagerduty_users.id]
+  escalation_policy_schedule_targets = [module.pagerduty_schedule.id]
   name                        = "test"
   repeat_loops                = 10
-  type                        = "user"
 }
+
 ```
 
 
@@ -63,10 +64,10 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | enabled | Gives ability to enable or disable a module | `bool` | `true` | no |
 | escalation\_delay\_in\_minutes | n/a | `number` | `15` | no |
-| escalation\_policy\_target\_id | n/a | `any` | n/a | yes |
+| escalation\_policy\_schedule\_targets | n/a | `list` | `[]` | no |
+| escalation\_policy\_users\_targets | n/a | `list` | `[]` | no |
 | name | Name of escalation policy. Make it meaningful | `any` | n/a | yes |
 | repeat\_loops | The number of times the escalation policy will repeat after reaching the end of its escalation. | `number` | `2` | no |
-| type | Can be user, schedule, user\_reference or schedule\_reference | `string` | `"schedule"` | no |
 
 ## Outputs
 
@@ -79,7 +80,7 @@ No requirements.
 ### Terraform Module Registry
 
 ![Hazelops logo](https://avatars0.githubusercontent.com/u/63737915?s=25&v=4) [Terraform Pagerduty Escalation Policy
-](https://registry.terraform.io/modules/address_of_module)
+](https://registry.terraform.io/modules/hazelops/escalation-policy/pagerduty/latest)
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ provider "pagerduty" {
   token = "Pagerduty_Token"
 }
 module "pagerduty_escalation" {
-  source  = "hazelops/escalation-policy/pagerduty"
-  escalation_policy_users_targets =    [module.pagerduty_users.id]
-  name                        = "test"
+  source                          = "hazelops/escalation-policy/pagerduty"
+  escalation_policy_users_targets = [module.pagerduty_users.id]
+  name                            = "test"
 }
 
 ```
@@ -34,13 +34,13 @@ provider "pagerduty" {
   token = "Pagerduty_Token"
 }
 module "pagerduty_escalation" {
-  source  = "hazelops/escalation-policy/pagerduty"
-  enabled                     = true
-  escalation_delay_in_minutes = 10
-  escalation_policy_users_targets =    [module.pagerduty_users.id]
+  source                             = "hazelops/escalation-policy/pagerduty"
+  enabled                            = true
+  escalation_delay_in_minutes        = 10
+  escalation_policy_users_targets    = [module.pagerduty_users.id]
   escalation_policy_schedule_targets = [module.pagerduty_schedule.id]
-  name                        = "test"
-  repeat_loops                = 10
+  name                               = "test"
+  repeat_loops                       = 10
 }
 
 ```
@@ -81,29 +81,3 @@ No requirements.
 
 ![Hazelops logo](https://avatars0.githubusercontent.com/u/63737915?s=25&v=4) [Terraform Pagerduty Escalation Policy
 ](https://registry.terraform.io/modules/hazelops/escalation-policy/pagerduty/latest)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/main.tf
+++ b/main.tf
@@ -22,5 +22,4 @@ resource "pagerduty_escalation_policy" "this" {
       }
     }
   }
-
 }

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,21 @@ resource "pagerduty_escalation_policy" "this" {
   rule {
     escalation_delay_in_minutes = var.escalation_delay_in_minutes
 
-    target {
-      type = var.type
-      id   = var.escalation_policy_target_id
+    dynamic "target" {
+      for_each = var.escalation_policy_users_targets
+      content {
+        type = "user"
+        id   = target.value
+      }
+    }
+
+    dynamic "target" {
+      for_each = var.escalation_policy_schedule_targets
+      content {
+        type = "schedule"
+        id   = target.value
+      }
     }
   }
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = pagerduty_escalation_policy.this[0].id
+  value = var.enabled ? pagerduty_escalation_policy.this[0].id : ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,11 +13,6 @@ variable "repeat_loops" {
   default = 2
 }
 
-variable "type" {
-  description = "Can be user, schedule, user_reference or schedule_reference"
-  default     = "schedule"
-}
-
 variable "escalation_delay_in_minutes" {
   default = 15
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,4 +22,10 @@ variable "escalation_delay_in_minutes" {
   default = 15
 }
 
-variable "escalation_policy_target_id" {}
+variable "escalation_policy_users_targets" {
+  default = []
+}
+
+variable "escalation_policy_schedule_targets" {
+  default = []
+}


### PR DESCRIPTION
#### What's new:

 - make creation of escalation policy less flexible but more convenient
   - left only two types of policy: `user` and `schedule`
   - add new variables: `escalation_policy_users_targets` and `escalation_policy_schedule_targets`
   - removed `type` variable
 - add ternary condition to the `output.tf` that helps to output zero value ("") in case when module is disabled